### PR TITLE
feat: dungeon schema update — enemies, user linking, new endpoints

### DIFF
--- a/backend/src/controllers/dungeonMap.controller.js
+++ b/backend/src/controllers/dungeonMap.controller.js
@@ -8,7 +8,6 @@ const generateDungeon = async (req, res) => {
     const seed = Math.floor(Math.random() * 999999);
     const { tiles } = generateMap(Number(width), Number(height), seed);
 
-    // Count objects
     const flatTiles = tiles.flat();
     const enemySpawnCount = flatTiles.filter(
       (t) => t.object === "enemy_spawn",
@@ -16,10 +15,22 @@ const generateDungeon = async (req, res) => {
     const chestCount = flatTiles.filter((t) => t.object === "chest").length;
     const trapCount = flatTiles.filter((t) => t.object === "trap").length;
 
-    // Fetch random enemies from Character collection
-    const enemies = await Character.aggregate([
-      { $sample: { size: enemySpawnCount } },
-    ]);
+    // Fetch all enemy characters (createdBy: null)
+    const availableEnemies = await Character.find({ createdBy: null });
+
+    if (availableEnemies.length === 0) {
+      return res.status(500).json({
+        success: false,
+        message: "No enemy characters found in database",
+      });
+    }
+
+    // Fill enemy list up to enemySpawnCount by placing multiple instances of the same enemy type  (if needed)
+    const enemyList = [];
+    for (let i = 0; i < enemySpawnCount; i++) {
+      const enemy = availableEnemies[i % availableEnemies.length];
+      enemyList.push({ enemy: enemy._id, status: "active" });
+    }
 
     const dungeon = await Dungeon.create({
       seed,
@@ -27,12 +38,18 @@ const generateDungeon = async (req, res) => {
       height: Number(height),
       level,
       tiles,
+      enemies: enemyList,
+      user: req.user.userId,
     });
 
-    res.status(200).json({
+    // Populate enemies before returning
+    const populatedDungeon = await Dungeon.findById(dungeon._id).populate(
+      "enemies.enemy",
+    );
+
+    res.status(201).json({
       success: true,
-      dungeon,
-      enemies,
+      dungeon: populatedDungeon,
       stats: { enemySpawnCount, chestCount, trapCount },
     });
   } catch (e) {
@@ -43,10 +60,28 @@ const generateDungeon = async (req, res) => {
   }
 };
 
-// Get a dungeon by ID
+// Get all dungeons for a user
+const getDungeons = async (req, res) => {
+  try {
+    const dungeons = await Dungeon.find({ user: req.user.userId }).select(
+      "-tiles -enemies",
+    );
+    res.status(200).json({ success: true, dungeons });
+  } catch (e) {
+    console.log(e);
+    res
+      .status(500)
+      .json({ success: false, message: "Could not retrieve dungeons" });
+  }
+};
+
+// Get a single dungeon by ID
 const getDungeon = async (req, res) => {
   try {
-    const dungeon = await Dungeon.findById(req.params.id);
+    const dungeon = await Dungeon.findOne({
+      _id: req.params.id,
+      user: req.user.userId,
+    }).populate("enemies.enemy");
     if (!dungeon)
       return res
         .status(404)
@@ -60,4 +95,25 @@ const getDungeon = async (req, res) => {
   }
 };
 
-module.exports = { generateDungeon, getDungeon };
+// Update dungeon — tiles and enemy statuses
+const updateDungeon = async (req, res) => {
+  try {
+    const dungeon = await Dungeon.findOneAndUpdate(
+      { _id: req.params.id, user: req.user.userId },
+      req.body,
+      { new: true, runValidators: true },
+    ).populate("enemies.enemy");
+    if (!dungeon)
+      return res
+        .status(404)
+        .json({ success: false, message: "Dungeon not found" });
+    res.status(200).json({ success: true, dungeon });
+  } catch (e) {
+    console.log(e);
+    res
+      .status(500)
+      .json({ success: false, message: "Could not update dungeon" });
+  }
+};
+
+module.exports = { generateDungeon, getDungeons, getDungeon, updateDungeon };

--- a/backend/src/middleware/authentication.js
+++ b/backend/src/middleware/authentication.js
@@ -3,6 +3,7 @@ const jwt = require("jsonwebtoken");
 
 const auth = async (req, res, next) => {
   const authHeader = req.headers.authorization;
+  console.log("Auth header received:", authHeader);
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     //console.log(error);
     return res.status(401).json({ message: "Authentication Invalid" });

--- a/backend/src/models/dungeonMap.js
+++ b/backend/src/models/dungeonMap.js
@@ -15,9 +15,21 @@ const TileSchema = new mongoose.Schema(
   { _id: false },
 );
 
+const DungeonEnemySchema = new mongoose.Schema(
+  {
+    enemy: { type: mongoose.Types.ObjectId, ref: "Character", required: true },
+    status: {
+      type: String,
+      enum: ["active", "defeated"],
+      default: "active",
+    },
+  },
+  { _id: false },
+);
+
 const DungeonSchema = new mongoose.Schema(
   {
-    user: { type: mongoose.Types.ObjectId, ref: "User", required: false },
+    user: { type: mongoose.Types.ObjectId, ref: "User", required: true },
     seed: { type: Number, required: true },
     width: { type: Number, required: true },
     height: { type: Number, required: true },
@@ -28,6 +40,7 @@ const DungeonSchema = new mongoose.Schema(
       default: "active",
     },
     tiles: { type: [[Object]], required: true },
+    enemies: { type: [DungeonEnemySchema], required: true },
   },
   { timestamps: true },
 );

--- a/backend/src/routes/dungeonMap.routes.js
+++ b/backend/src/routes/dungeonMap.routes.js
@@ -2,11 +2,19 @@ const express = require("express");
 const router = express.Router();
 const {
   generateDungeon,
+  getDungeons,
+  // getDungeons — lists all user dungeons, metadata only (no tiles/enemies). Like a save file selection screen.
+
   getDungeon,
+  // getDungeon — returns one full dungeon with tiles and populated enemies. Like loading a save file to play.
+
+  updateDungeon,
 } = require("../controllers/dungeonMap.controller");
 const authMiddleware = require("../middleware/authentication");
 
 router.route("/generate").get(authMiddleware, generateDungeon);
+router.route("/").get(authMiddleware, getDungeons);
 router.route("/:id").get(authMiddleware, getDungeon);
+router.route("/:id").patch(authMiddleware, updateDungeon);
 
 module.exports = router;


### PR DESCRIPTION
1. Updated dungeon schema to include:
   - enemies list with { enemy: CharacterId, status: "active/defeated" }
   - user field (required) to link dungeon to its owner

2. Updated generateDungeon controller:
   - Only fetches characters where createdBy is null (enemy characters only)
   - Fills enemy list up to enemySpawnCount by reusing characters if needed
   - Saves enemies directly to dungeon document not just the response
   - Links dungeon to logged in user via req.user.userId
   - Populates full enemy data before returning response

3. Added getDungeons endpoint — GET /api/dungeon
   - Returns all dungeons for logged in user
   - Excludes tiles and enemies for a lightweight response (save file list)

4. Added updateDungeon endpoint — PATCH /api/dungeon/:id
   - Updates dungeon state including enemy statuses and tile objects
   - Filters by user so players can only update their own dungeons